### PR TITLE
Fix the adjusted coordinates, fixes OsakaStarbux/Train-game#1

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -121,11 +121,11 @@ function containsPoint(topLeft, bottomRight, point){
 // convert window coordinates to canvas coordinates
 // TODO: make this work
 function adjustX(val){
-  return 100 + val - course.train.x / 2;
+  return  val - (300) + course.train.x;
 }
 
 function adjustY(val){
-  return (val - course.train.y - height / 2) * 2;
+  return val - 200;
 }
 
 // offset functions to place the viewport on the canvas


### PR DESCRIPTION
So this is not super nice because I just used the magic numbers 300 and 200 for the initial train position since I did not know if you  store them in a variable somewhere.

But when I run it now I am able to tap signals (But it is hard to hit them since their hitbox might be a bit small?)

And when I mouseover the train in the end the adjusted mouse positions are now equal to the train position.

I hope this is what you wanted, it seems to work since the coords for the mouse line up with the train on the whole trip